### PR TITLE
Use a default value for coursework LOs

### DIFF
--- a/.github/ISSUE_TEMPLATE/coursework.yml
+++ b/.github/ISSUE_TEMPLATE/coursework.yml
@@ -25,7 +25,7 @@ body:
     attributes:
       label: Learning Objectives
       description: https://common.codeyourfuture.io/common-theme/shortcodes/objectives/
-      placeholder: |
+      value: |
         <!--{{<objectives}}--> 
         - [ ] CYF format, task list formatting
         <!--{{</objectives}}-->


### PR DESCRIPTION
## Learners, PR Template

Self checklist

- [x] I have committed my files one by one, on purpose, and for a reason
- [x] I have tested my changes
- [x] My changes follow the [style guide](https://syllabus.codeyourfuture.io/guides/code-style-guide/)
- [x] My changes meet the [requirements](./README.md) of this task

## Changelist

Previously we were using a placeholder, instead of a value, and this means that the moment you type something the placeholder disappears, and you probably can't remember what format you were meant to use.