### PR TITLE
Remove command palette from list of requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ Remember: There's no "correct" path through this workshop. The goal is to develo
 - I can find the issues view, the pull request view, and the file tree view on any GitHub repo
 - I know how to create an issue and attach labels
 - I have a strategy for finding things in the GitHub interface
-- I can bring up the search and the command palette
+- I can bring up the search


### PR DESCRIPTION
## Learners, PR Template

Self checklist

- [x] I have committed my files one by one, on purpose, and for a reason
- [x] I have tested my changes
- [x] My changes follow the [style guide](https://syllabus.codeyourfuture.io/guides/code-style-guide/)
- [x] My changes meet the [requirements](./README.md) of this task

## Changelist

As far as I can tell, GitHub doesn't have a command palette, that's a VS Code concept.

## Questions

Is there a command palette I don't know about / can't see?